### PR TITLE
fixes hydration failure from markdown summaries rendered inside <p>

### DIFF
--- a/components/news/TrendingNews.css
+++ b/components/news/TrendingNews.css
@@ -358,6 +358,16 @@
   margin: 0 0 1rem 0;
 }
 
+/* The summary holds markdown rendered to block-level HTML, so the spacing
+   belongs to the paragraphs inside it. */
+.trending-news-summary p {
+  margin: 0 0 1rem 0;
+}
+
+.trending-news-summary p:last-child {
+  margin-bottom: 0;
+}
+
 .citations-container {
   margin-top: 1rem;
 }

--- a/components/news/TrendingNews.jsx
+++ b/components/news/TrendingNews.jsx
@@ -75,7 +75,9 @@ export default function TrendingNews({languageSections, currentLang, currentDate
     return response || responses[0];
   };
 
-  // Get trending reason from API data
+  // Get trending reason from API data. micromark emits block-level HTML
+  // (`<p>…</p>`), so the result must be injected into a block container — a
+  // <p> here produces invalid nesting and breaks hydration.
   const getPeopleSummary = person => {
     const response = getActiveModelResponse(person);
     return micromark(response?.reason || "");
@@ -192,7 +194,7 @@ export default function TrendingNews({languageSections, currentLang, currentDate
               {person.localized_occupation || person.occupation || "Unknown"}
             </span>
             {!isExpanded && (
-              <p className="mobile-card-preview" dangerouslySetInnerHTML={{__html: getPeopleSummary(person)}} />
+              <div className="mobile-card-preview" dangerouslySetInnerHTML={{__html: getPeopleSummary(person)}} />
             )}
           </div>
           <span className={`mobile-expand-icon ${isExpanded ? "open" : ""}`}>&#9662;</span>
@@ -201,7 +203,7 @@ export default function TrendingNews({languageSections, currentLang, currentDate
         {/* Mobile expanded detail */}
         {isExpanded && (
           <div className="mobile-card-detail">
-            <p
+            <div
               className="trending-news-summary"
               dangerouslySetInnerHTML={{__html: getPeopleSummary(person)}}
             />
@@ -284,7 +286,7 @@ export default function TrendingNews({languageSections, currentLang, currentDate
             <p className="trending-news-occupation">
               {person.localized_occupation || person.occupation || "Unknown"}
             </p>
-            <p
+            <div
               className="trending-news-summary"
               dangerouslySetInnerHTML={{__html: getPeopleSummary(person)}}
             />

--- a/components/person/WhyTrending.css
+++ b/components/person/WhyTrending.css
@@ -111,7 +111,7 @@
   }
 
 
-  .reason-container > p{
+  .reason-container > .reason-text{
     width: 65%;
     @media (max-width: 550px) {
         width: 100%;

--- a/components/person/WhyTrending.jsx
+++ b/components/person/WhyTrending.jsx
@@ -70,7 +70,7 @@ export default function WhyTrending({
           <div className="reason-header">
             <h3>{t.trending.whyTrending.replace("{name}", person.name)}</h3>
           </div>
-          <p dangerouslySetInnerHTML={{__html: reasonHtml}} />
+          <div className="reason-text" dangerouslySetInnerHTML={{__html: reasonHtml}} />
           {citations.length > 0 && (
             <div className="citations-container">
               <h4>{t.trending.references}</h4>

--- a/tests/e2e/hydration.spec.js
+++ b/tests/e2e/hydration.spec.js
@@ -1,0 +1,54 @@
+import {expect, test} from "@playwright/test";
+import {firstHref, goto} from "./helpers.js";
+
+/**
+ * Trending summaries are markdown rendered with micromark, which emits
+ * BLOCK-level HTML (`<p>…</p>`), so they must be injected into a block
+ * container. Injecting them into a `<p>` ships `<p><p>…</p></p>`, and the HTML
+ * parser is required to close the outer paragraph at the inner one — the
+ * summary text lands in a SIBLING node instead of inside the container. The
+ * client tree still nests it, so hydration throws
+ *   "Hydration failed because the server rendered HTML didn't match the client"
+ * (React #418) on /news and on every trending person profile.
+ *
+ * These run with JavaScript disabled so the assertions see the server-rendered
+ * DOM exactly as the browser parses it — that is where the nesting is lost;
+ * once React re-renders the subtree on the client the structure looks fine
+ * again.
+ */
+test.describe("server-rendered markdown survives HTML parsing", () => {
+  test.use({javaScriptEnabled: false});
+
+  test("trending news summaries render inside their container", async ({page}) => {
+    await goto(page, "/news");
+
+    const summary = page
+      .locator(".desktop-card-content .trending-news-summary")
+      .first();
+    await expect(summary).toBeAttached();
+    await expect(
+      summary.locator("p"),
+      "summary container lost its markdown paragraph to the HTML parser",
+    ).not.toHaveCount(0);
+    await expect(summary).not.toHaveText(/^\s*$/);
+  });
+
+  test("no block element opens directly inside a paragraph", async ({page}) => {
+    // A trending person profile renders the same summary through WhyTrending,
+    // so check both pages. The slug is discovered from /news rather than
+    // hardcoded — who is trending changes daily.
+    await goto(page, "/news");
+    const personHref = await firstHref(page, /\/profile\/person\//);
+
+    const paths = ["/news", ...(personHref ? [personHref] : [])];
+    for (const path of paths) {
+      const res = await page.request.get(path);
+      expect(res.status(), `${path} returned HTTP ${res.status()}`).toBeLessThan(400);
+      const html = await res.text();
+      expect(
+        html,
+        `${path} nests a block element inside a <p>`,
+      ).not.toMatch(/<p\b[^>]*>\s*<(?:p|div|ul|ol|blockquote|pre|h[1-6])\b/i);
+    }
+  });
+});


### PR DESCRIPTION
This PR proposes fixing the hydration failure on `/news` and on trending person profiles, where markdown summaries are rendered into a `<p>` and the resulting invalid nesting breaks React hydration. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/331. You can sign in with your GitHub ID to claim ownership of the project.

## The defect

Trending reasons are markdown rendered with `micromark`, which emits block-level HTML (`<p>…</p>`). That output is injected into a `<p>` element at four places — three in `components/news/TrendingNews.jsx` (mobile preview, mobile detail, desktop card) and one in `components/person/WhyTrending.jsx`. HTML does not allow a paragraph inside a paragraph, so the parser must close the outer `<p>` at the inner one: the server DOM ends up with the summary as a *sibling* of an empty `<p class="trending-news-summary">`, while the client tree nests it. Hydration fails, React throws, and the whole subtree is thrown away and re-rendered on the client on every visit.

This is red in your own smoke suite at `91bfd5e`. `npm run build && npm start` (with `BASE_API=https://api.pantheon.world`), then:

```
$ npx playwright test static-and-index
  1) [chromium] › tests/e2e/static-and-index.spec.js:26:7 › static: news (/news)
    Error: Uncaught JS error(s):
    Minified React error #418; visit https://react.dev/errors/418?args[]=HTML&args[]=
  1 failed
  116 passed (2.6m)
```

Against a dev server the un-minified error names the element directly:

```
Hydration failed because the server rendered HTML didn't match the client.
...
  <p
    className="mobile-card-preview"
    dangerouslySetInnerHTML={{
+     __html: "<p>Actress Lucy Davis is trending today after revealing she has been diag..."
-     __html: ""
    }}
  >
- <p>
- <p>
```

The served markup shows it plainly on both surfaces — `curl -s localhost:3000/news | grep -o '<p class="trending-news-summary"><p>'` matches, and so does `/profile/person/<a trending slug>`, which renders `<p><p>…</p></p>` through `WhyTrending`.

## The change

The four summaries now render into block containers rather than paragraphs, which is what the markdown output requires. Paragraph spacing moves onto the inner `<p>` (`.trending-news-summary p`), mirroring the rule your mobile detail view already has, so the rendering does not move: measured at 1280px, summary heights are byte-identical before and after (276 / 255 / 255 / 319 px) and card height changes by 5px purely from the normalized margin collapse. On the person profile, `.reason-container > p { width: 65% }` became `.reason-container > .reason-text` so that width still applies to the summary and not to the paragraphs inside it — measured at 627px of a 964px content box after the change, i.e. the same 65%.

Verification, all against `BASE_API=https://api.pantheon.world`:

- **Baseline before the change:** full suite `1 failed, 116 passed` — the failure being `static: news (/news)`.
- **After the change:** full suite `119 passed`, no failures. The previously red news test passes, and no test that was green went red.
- **Regression test:** `tests/e2e/hydration.spec.js` is new and runs with JavaScript disabled, so it asserts the server-rendered DOM exactly as the parser produced it — that is the only place the nesting is observable, since React repairs the structure once it re-renders on the client. It fails on the unpatched tree (`2 failed`: the summary container resolves to 0 inner paragraphs) and passes on the patched one. The second test asserts the broader invariant — no block element opens directly inside a `<p>` — on `/news` and on a trending person profile discovered from it, so the same mistake cannot come back through a different component.
- **Runtime check:** loading `/news` and a trending person profile in a browser produces zero uncaught page errors after the change; both produced React #418 before it.
- `npm run lint` reports exactly the same 667 problems as it does on a clean checkout, and the changed files lint clean on their own.

## How this was managed

We imported this repo's issues and pull requests into a live agile board — 189 stories, 10 labels — and worked this fix on it as [story #213783](https://eastagiletracker.com/projects/331/stories/213783), from reproduction through to the regression test. The board is public and browsable at https://eastagiletracker.com/projects/331.

![board](https://raw.githubusercontent.com/eastagiletracker/pantheon2/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
